### PR TITLE
Bug fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "wpdetect"
 version = "1.4.8"
 dependencies = [
-    "pyfiglet", "requests", "click", "toml"
+    "pyfiglet", "requests", "click"
 ]
 authors = [
   { name="S M Mahmudul Hasan", email="he@smmahmudulhasan.com" },

--- a/utils/bump_version.py
+++ b/utils/bump_version.py
@@ -6,6 +6,20 @@ import os
 import toml
 
 
+def write_changes_to_file(file_location, checker, version):
+    """Writes the changes to the file."""
+
+    with open(file_location, 'r', encoding="utf-8") as file:
+        lines = file.readlines()
+
+    with open(file_location, 'w', encoding="utf-8") as file:
+        for line in lines:
+            if line.startswith(checker):
+                file.write(f'{checker} = "{version}"\n')
+            else:
+                file.write(line)
+
+
 def increment_version():
     """Increments the version in pyproject.toml and returns the new version."""
 
@@ -23,15 +37,10 @@ def increment_version():
     new_version = '.'.join(version_parts)
 
     # Update the version in pyproject.toml
-    with open(file_path, 'r', encoding="utf-8") as file:
-        lines = file.readlines()
+    write_changes_to_file(file_path, 'version', new_version)
 
-    with open(file_path, 'w', encoding="utf-8") as file:
-        for line in lines:
-            if line.startswith('version'):
-                file.write(f'version = "{new_version}"\n')
-            else:
-                file.write(line)
+    # Update the version in wpdetect/__main__.py
+    write_changes_to_file('wpdetect/__main__.py', 'VERSION', new_version)
 
     return new_version
 

--- a/wpdetect/__main__.py
+++ b/wpdetect/__main__.py
@@ -6,12 +6,12 @@ description: A simple script to detect if a website is running WordPress.
 import sys
 import urllib.request
 from urllib.parse import urlparse
-import toml
 import click
 from pyfiglet import figlet_format
 
 HEADER = "'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_3) AppleWebKit/537.75.14" + \
     " (KHTML, like Gecko) Version/7.0.3 Safari/7046A194A'"
+VERSION = "1.4.8"
 
 # Error messages
 ERROR_UNABLE_TO_OPEN_URL = "Couldn't open url," + \
@@ -32,11 +32,7 @@ cli_options = {
 def get_package_version():
     """Returns the version of the package."""
 
-    # using absolute path to open the file because of the issue: #31
-    with open('pyproject.toml', 'r', encoding="utf-8") as pyproject_toml_file:
-        config = toml.load(pyproject_toml_file)
-
-    return config['project']['version']
+    return VERSION
 
 
 def print_verbose(message):


### PR DESCRIPTION
`wpdetect -v` or `wpdetect wordpress.org` was giving file not found error for `pyproject.toml` because that file is never packaged in this package. 

So, when incrementing the version in `pyproject.toml` during version bump, updated it on` __main__.py` as well.